### PR TITLE
Reworks the infinite recursion into a form that Ratpack currently supports.

### DIFF
--- a/src/main/java/infinity/InfinityRecursionAction.java
+++ b/src/main/java/infinity/InfinityRecursionAction.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ratpack.exec.Blocking;
 import ratpack.exec.Execution;
+import ratpack.exec.Operation;
 import ratpack.exec.Promise;
 import ratpack.func.Action;
 
@@ -18,28 +19,25 @@ public class InfinityRecursionAction implements Action<Execution> {
 
     @Override
     public void execute(Execution execution) throws Exception {
-        poll()
-            .result(r -> {
-                Throwable error = r.getThrowable();
-                LOG.error("Unexpected error", error);
-            });
+        Operation.of(this::loop)
+            .onError(e -> LOG.error("Unexpected error", e))
+            .then();
     }
 
-    private Promise<Void> poll() {
-        return getFoo()
-            .flatMap(this::useFoo)
-            .flatMap(v -> this.poll());
+    private void loop() {
+        poll().then(this::loop);
+    }
+
+    private Operation poll() {
+        return getFoo().operation(this::useFoo);
     }
 
     private Promise<Foo> getFoo() {
         return Blocking.get(Foo::new);
     }
 
-    private Promise<Void> useFoo(Foo foo) {
-        return Blocking.get(() -> {
-            LOG.debug("foo={}", foo.name);
-            return null;
-        });
+    private void useFoo(Foo foo) {
+        Blocking.exec(() -> LOG.debug("foo={}", foo.name));
     }
 
     private static class Foo {


### PR DESCRIPTION
Nesting promises together infinitely does indeed lead to heap exhaustion. This is effectively because promise are yielded lazily. In the code that's their, each time we recurse we are creating objects that define what to do when the function returns. We are effectively digging a hole, that we have to return something out of.

The solution that works today is to actually chain things instead of nest. Arguably, this is more natural than working with `Promise<Void>` and nesting.

Please take a look at this solution and let me know if anything's not clear and if you'd like me to expand on it.

